### PR TITLE
feat(storagelist): Add storages list, group shared by storage name

### DIFF
--- a/src/pvecontrol/__init__.py
+++ b/src/pvecontrol/__init__.py
@@ -30,8 +30,9 @@ def _parser():
   parser_clusterstatus.set_defaults(func=cluster.action_clusterstatus)
 
   # storagelist parser
-  parser_clusterstatus = subparsers.add_parser('storagelist', help='Show cluster status')
-  parser_clusterstatus.set_defaults(func=storage.action_storagelist)
+  parser_storagelist = subparsers.add_parser('storagelist', help='Show cluster status')
+  parser_storagelist.add_argument('--sort-by', action='store', help="Key used to sort items", default="storage")
+  parser_storagelist.set_defaults(func=storage.action_storagelist)
 
   # nodelist parser
   parser_nodelist = subparsers.add_parser('nodelist', help='List nodes in the cluster')

--- a/src/pvecontrol/__init__.py
+++ b/src/pvecontrol/__init__.py
@@ -8,7 +8,7 @@ import logging
 
 from pvecontrol.cluster import PVECluster
 from pvecontrol.config import set_config
-from pvecontrol.actions import cluster, node, vm, task
+from pvecontrol.actions import cluster, node, vm, storage, task
 
 def action_test(proxmox, args):
   """Hidden optional test action"""
@@ -28,6 +28,10 @@ def _parser():
   # clusterstatus parser
   parser_clusterstatus = subparsers.add_parser('clusterstatus', help='Show cluster status')
   parser_clusterstatus.set_defaults(func=cluster.action_clusterstatus)
+
+  # storagelist parser
+  parser_clusterstatus = subparsers.add_parser('storagelist', help='Show cluster status')
+  parser_clusterstatus.set_defaults(func=storage.action_storagelist)
 
   # nodelist parser
   parser_nodelist = subparsers.add_parser('nodelist', help='List nodes in the cluster')

--- a/src/pvecontrol/actions/storage.py
+++ b/src/pvecontrol/actions/storage.py
@@ -4,6 +4,7 @@ from pvecontrol.utils import filter_keys, print_tableoutput
 
 def action_storagelist(proxmox, args):
   """Describe cluster storages"""
+  sortby = args.sort_by
   keys_to_order = ['storage', 'nodes', 'shared', 'usage', 'maxdisk', 'disk', 'plugintype', 'status']
   storages = {}
   for storage in proxmox.storages:
@@ -25,4 +26,4 @@ def action_storagelist(proxmox, args):
     storages[id]['nodes'] = ', '.join(storages[id]['nodes'])
 
   output = [ filter_keys(n, keys_to_order) for n in storages.values()]
-  print_tableoutput(output, sortby='storage')
+  print_tableoutput(output, sortby)

--- a/src/pvecontrol/actions/storage.py
+++ b/src/pvecontrol/actions/storage.py
@@ -1,0 +1,27 @@
+from pvecontrol.utils import filter_keys, print_tableoutput
+
+
+def action_storagelist(proxmox, args):
+  """Describe cluster storages"""
+  keys_to_order = ['storage', 'nodes', 'shared', 'usage', 'maxdisk', 'disk', 'plugintype', 'status']
+  storages = {}
+  for storage in proxmox.storages:
+    d = storage.__dict__
+    node = d.pop('node')
+    value = {
+      **d,
+      'nodes': [],
+      'usage': f"{storage.percentage:.1f}%"
+    }
+    if storage.shared:
+      storages[storage.storage] = storages.get(storage.storage, value)
+      storages[storage.storage]['nodes'] += [node]
+    else:
+      storages[storage.id] = value
+      storages[storage.id]['nodes'] += [node]
+
+  for id, storage in storages.items():
+    storages[id]['nodes'] = ', '.join(storages[id]['nodes'])
+
+  output = [ filter_keys(n, keys_to_order) for n in storages.values()]
+  print_tableoutput(output, sortby='storage')

--- a/src/pvecontrol/actions/storage.py
+++ b/src/pvecontrol/actions/storage.py
@@ -1,3 +1,4 @@
+from pvecontrol.storage import StorageShared
 from pvecontrol.utils import filter_keys, print_tableoutput
 
 
@@ -13,7 +14,7 @@ def action_storagelist(proxmox, args):
       'nodes': [],
       'usage': f"{storage.percentage:.1f}%"
     }
-    if storage.shared:
+    if StorageShared[storage.shared] == StorageShared.shared:
       storages[storage.storage] = storages.get(storage.storage, value)
       storages[storage.storage]['nodes'] += [node]
     else:

--- a/src/pvecontrol/cluster.py
+++ b/src/pvecontrol/cluster.py
@@ -24,7 +24,7 @@ class PVECluster:
 
     self.storages = []
     for storage in self.get_resources_storages():
-      self.storages.append(PVEStorage(storage.pop("node"), storage.pop("id"), **storage))
+      self.storages.append(PVEStorage(storage.pop("node"), storage.pop("id"), storage.pop("shared"), **storage))
 
     self.tasks = []
     for task in self._api.cluster.tasks.get():

--- a/src/pvecontrol/cluster.py
+++ b/src/pvecontrol/cluster.py
@@ -1,6 +1,7 @@
 from proxmoxer import ProxmoxAPI
 
 from pvecontrol.node import PVENode
+from pvecontrol.storage import PVEStorage
 from pvecontrol.task import PVETask
 
 
@@ -20,6 +21,10 @@ class PVECluster:
     self.nodes = []
     for node in self._api.nodes.get():
       self.nodes.append(PVENode(self._api, node["node"], node["status"], node))
+
+    self.storages = []
+    for storage in self.get_resources_storages():
+      self.storages.append(PVEStorage(storage.pop("node"), storage.pop("id"), **storage))
 
     self.tasks = []
     for task in self._api.cluster.tasks.get():

--- a/src/pvecontrol/storage.py
+++ b/src/pvecontrol/storage.py
@@ -1,0 +1,26 @@
+class PVEStorage:
+  """Proxmox VE Storage"""
+
+  _acceptable_kwargs = (
+    'storage', 'shared', 'maxdisk', 'disk', 'plugintype', 'status'
+  )
+
+  def __init__(self, node, id, **kwargs):
+    self.id = id
+    self.node = node
+
+    for k in kwargs.keys():
+      if k in self._acceptable_kwargs:
+        self.__setattr__(k, kwargs[k])
+
+  @property
+  def percentage(self):
+    if self.maxdisk:
+      return self.disk / self.maxdisk *100
+    return 0
+
+  def __str__(self):
+    output = f"Node: {self.node}\n" + f"Id: {self.id}\n"
+    for key in self._acceptable_kwargs:
+      output += f"{key.capitalize()}: {self.__getattribute__(key)}\n"
+    return output

--- a/src/pvecontrol/storage.py
+++ b/src/pvecontrol/storage.py
@@ -1,13 +1,24 @@
+from enum import Enum
+
+
+STORAGE_SHARED_ENUM = ['local', 'shared']
+
+class StorageShared(Enum):
+  local = 0
+  shared = 1
+
 class PVEStorage:
   """Proxmox VE Storage"""
 
   _acceptable_kwargs = (
-    'storage', 'shared', 'maxdisk', 'disk', 'plugintype', 'status'
+    'storage', 'maxdisk', 'disk', 'plugintype', 'status'
   )
 
-  def __init__(self, node, id, **kwargs):
+  def __init__(self, node, id, shared, **kwargs):
     self.id = id
     self.node = node
+
+    self.shared = STORAGE_SHARED_ENUM[shared]
 
     for k in kwargs.keys():
       if k in self._acceptable_kwargs:

--- a/src/pvecontrol/storage.py
+++ b/src/pvecontrol/storage.py
@@ -10,9 +10,14 @@ class StorageShared(Enum):
 class PVEStorage:
   """Proxmox VE Storage"""
 
-  _acceptable_kwargs = (
-    'storage', 'maxdisk', 'disk', 'plugintype', 'status'
-  )
+  _default_kwargs = {
+    'storage': None,
+    'maxdisk': None,
+    'disk': None,
+    'plugintype': None,
+    'status': None,
+    'test': None,
+  }
 
   def __init__(self, node, id, shared, **kwargs):
     self.id = id
@@ -20,9 +25,8 @@ class PVEStorage:
 
     self.shared = STORAGE_SHARED_ENUM[shared]
 
-    for k in kwargs.keys():
-      if k in self._acceptable_kwargs:
-        self.__setattr__(k, kwargs[k])
+    for k, v in self._default_kwargs.items():
+        self.__setattr__(k, kwargs.get(k, v))
 
   @property
   def percentage(self):


### PR DESCRIPTION
Output example:

```
python src/pvecontrol.py -c my-cluster storagelist
INFO:root:Proxmox cluster: my-cluster
+--------------------+---------------------+--------+-------+-----------+-----------+------------+-----------+
| storage            | nodes               | shared | usage | maxdisk   | disk      | plugintype | status    |
+--------------------+---------------------+--------+-------+-----------+-----------+------------+-----------+
| backup             | pve-4, pve-3, pve-5 | shared | 68.5% | 14.2 TiB  | 9.7 TiB   | pbs        | available |
| templates          | pve-3               | local  | 0.0%  | 93.1 GiB  | 0 Bytes   | s3         | available |
| templates          | pve-4               | local  | 0.0%  | 93.1 GiB  | 0 Bytes   | s3         | available |
| templates          | pve-5               | local  | 0.0%  | 93.1 GiB  | 0 Bytes   | s3         | available |
| flatcar            | pve-4, pve-3, pve-5 | shared | 0.1%  | 128.0 MiB | 104.0 KiB | dir        | available |
| iscivg             | pve-4, pve-3, pve-5 | shared | 89.8% | 12.8 TiB  | 11.5 TiB  | lvm        | available |
| local              | pve-3               | local  | 33.7% | 31.3 GiB  | 10.5 GiB  | dir        | available |
| local              | pve-4               | local  | 30.3% | 31.3 GiB  | 9.5 GiB   | dir        | available |
| local              | pve-5               | local  | 31.0% | 31.3 GiB  | 9.7 GiB   | dir        | available |
| localvg            | pve-3               | local  | 90.2% | 3.5 TiB   | 3.1 TiB   | lvm        | available |
| localvg            | pve-4               | local  | 86.4% | 3.5 TiB   | 3.0 TiB   | lvm        | available |
| localvg            | pve-5               | local  | 85.6% | 3.5 TiB   | 3.0 TiB   | lvm        | available |
| stor-iscsi         | pve-4, pve-3, pve-5 | shared | 0.0%  | 0 Bytes   | 0 Bytes   | iscsi      | available |
+--------------------+---------------------+--------+-------+-----------+-----------+------------+-----------+
```