### PR TITLE
Nicely handle vanished tasks

### DIFF
--- a/src/pvecontrol/cluster.py
+++ b/src/pvecontrol/cluster.py
@@ -1,3 +1,5 @@
+import logging
+
 from proxmoxer import ProxmoxAPI
 
 from pvecontrol.node import PVENode
@@ -23,6 +25,7 @@ class PVECluster:
 
     self.tasks = []
     for task in self._api.cluster.tasks.get():
+      logging.debug("Get task informations: %s"%(str(task)))
       self.tasks.append(PVETask(self._api, task["upid"]))
 
   def refresh(self):

--- a/src/pvecontrol/utils.py
+++ b/src/pvecontrol/utils.py
@@ -34,6 +34,10 @@ def print_taskstatus(task):
 def print_task(proxmox, upid, follow = False, wait = False, show_logs = False):
   task = proxmox.find_task(upid)
   logging.debug("Task: %s", task)
+  # Vanished tasks don't have any more information available in the API
+  if task.vanished():
+    print_taskstatus(task)
+    return
 
   if task.running() and (follow or wait):
     print_taskstatus(task)


### PR DESCRIPTION
Some tasks can deseappear from the API with time. So we must handle this case.