### PR TITLE
feat: support for proxmox clusters behind a reverse proxy with certificate-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,25 @@ clusters:
     token_value: randomtokenvalue
 ```
 
+### Reverse proxies
+
+`pvecontrol` supports certificate-based authentication to a reverse proxy. Which makes it suitable for use with tools like [teleport](https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/) using teleport apps.
+
+```yaml
+clusters:
+  - name: fr-par-1
+    host: localhost
+    user: pvecontrol@pve
+    password: my.password.is.weak
+    proxy_certificate_path: /tmp/proxmox-reverse-proxy.pem
+    proxy_certificate_key_path: /tmp/proxmox-reverse-proxy
+```
+
+CAUTION: environment variable and `~` expansion and are not supported.
+
 ### Better security
 
-Instead of specifying users and passwords in plain text in the configuration file, you can use the shell command substitution syntax `$(...)` inside the `user` and `password` fields; for instance:
+Instead of specifying users, passwords and certificates paths in plain text in the configuration file, you can use the shell command substitution syntax `$(...)` inside the `user`, `password`, `proxy_certificate_path` and `proxy_certificate_path_key` fields; for instance:
 
 ```yaml
 clusters:

--- a/README.md
+++ b/README.md
@@ -95,11 +95,32 @@ clusters:
     proxy_certificate_key_path: /tmp/proxmox-reverse-proxy
 ```
 
+You can also use command substitution syntax and the key `proxy_certificate` to execute a command that will output a json containing the certficate and key paths.
+
+```yaml
+clusters:
+  - name: fr-par-1
+    host: localhost
+    user: pvecontrol@pve
+    password: my.password.is.weak
+    proxy_certificate: $(my_custom_command login proxmox-fr-par-1)
+```
+
+It should output something like this:
+
+```json
+{
+  "cert": "/tmp/proxmox-reverse-proxy.pem",
+  "key": "/tmp/proxmox-reverse-proxy",
+  "anything_else": "it is ok to have other fields, they will be ignored. this is to support existing commands"
+}
+```
+
 CAUTION: environment variable and `~` expansion and are not supported.
 
 ### Better security
 
-Instead of specifying users, passwords and certificates paths in plain text in the configuration file, you can use the shell command substitution syntax `$(...)` inside the `user`, `password`, `proxy_certificate_path` and `proxy_certificate_path_key` fields; for instance:
+Instead of specifying users, passwords and certificates paths in plain text in the configuration file, you can use the shell command substitution syntax `$(...)` inside the `user`, `password`, `proxy_certificate` fields; for instance:
 
 ```yaml
 clusters:

--- a/src/pvecontrol/config.py
+++ b/src/pvecontrol/config.py
@@ -10,8 +10,18 @@ configtemplate = {
             "host": str,
             "user": str,
             "password": confuse.Optional(str, None),
-            "proxy_certificate_path": confuse.Optional(str, None),
-            "proxy_certificate_key_path": confuse.Optional(str, None),
+            "proxy_certificate": confuse.Optional(
+                confuse.OneOf(
+                    [
+                        str,
+                        {
+                            "cert": str,
+                            "key": str,
+                        },
+                    ]
+                ),
+                None,
+            ),
             "token_name": confuse.Optional(str, None),
             "token_value": confuse.Optional(str, None),
             "node": confuse.Optional(

--- a/src/pvecontrol/config.py
+++ b/src/pvecontrol/config.py
@@ -10,6 +10,8 @@ configtemplate = {
             "host": str,
             "user": str,
             "password": confuse.Optional(str, None),
+            "proxy_certificate_path": confuse.Optional(str, None),
+            "proxy_certificate_key_path": confuse.Optional(str, None),
             "token_name": confuse.Optional(str, None),
             "token_value": confuse.Optional(str, None),
             "node": confuse.Optional(


### PR DESCRIPTION
Added two new configuration entries: `clusters[].proxy_certificate.cert` and `clusters[].proxy_certificate.cert`, which are paths to the certificate and its key used to authenticate against reverse proxies that proxmox clusters are behind. They are optional and can be set by using the shell command substitution syntax `$(...)` just as for the password with the difference that this syntax is on the `clusters[].proxy_certificate` configuration entry.

An example is always better:

```yaml
clusters:
  - name: fr-par-1
    host: some-reverse-proxy.com
    user: pvecontrol@pve
    password: my.password.is.weak
    # command substitution
    proxy_certificate: $(my_custom_command login proxmox-fr-par-1)
    # or hardcoded, both are valid
    proxy_certificate:
      cert: /tmp/proxmox-reverse-proxy.pem
      key: /tmp/proxmox-reverse-proxy
```