### PR TITLE
feat: enable various outputs (yaml, json) for clusterstatus

### DIFF
--- a/src/pvecontrol/actions/cluster.py
+++ b/src/pvecontrol/actions/cluster.py
@@ -59,19 +59,17 @@ def status(ctx):
 """
         )
     else:
-        render_table = [
-            dict(
-                status=cluster_status,
-                vm=vms - templates,
-                templates=templates,
-                metrics=metrics,
-                nodes=dict(
-                    offline=len([node for node in proxmox.nodes if node.status == NodeStatus.OFFLINE]),
-                    online=len([node for node in proxmox.nodes if node.status == NodeStatus.ONLINE]),
-                    unknown=len([node for node in proxmox.nodes if node.status == NodeStatus.UNKNOWN]),
-                ),
-            )
-        ]
+        render_table = [{
+            "status": cluster_status,
+            "vm": vms - templates,
+            "templates": templates,
+            "metrics": metrics,
+            "nodes": {
+                "offline": len([node for node in proxmox.nodes if node.status == NodeStatus.OFFLINE]),
+                "online": len([node for node in proxmox.nodes if node.status == NodeStatus.ONLINE]),
+                "unknown": len([node for node in proxmox.nodes if node.status == NodeStatus.UNKNOWN]),
+            }
+        }]
         print(render_output(render_table, output=ctx.obj["args"].output))
 
 

--- a/src/pvecontrol/actions/cluster.py
+++ b/src/pvecontrol/actions/cluster.py
@@ -42,8 +42,9 @@ def status(ctx):
         d_percent = metrics["disk"]["percent"]
         return f"{d_usage}/{d_total}({d_percent:.1f}%)"
 
-    if ctx.obj['args'].output == OutputFormats.TEXT:
-        print(f"""\n\
+    if ctx.obj["args"].output == OutputFormats.TEXT:
+        print(
+            f"""\n\
   Status: {cluster_status}
   VMs: {vms - templates}
   Templates: {templates}
@@ -55,7 +56,8 @@ def status(ctx):
     Offline: {len([node for node in proxmox.nodes if node.status == NodeStatus.OFFLINE])}
     Online: {len([node for node in proxmox.nodes if node.status == NodeStatus.ONLINE])}
     Unknown: {len([node for node in proxmox.nodes if node.status == NodeStatus.UNKNOWN])}
-""")
+"""
+        )
     else:
         render_table = [
             dict(
@@ -70,7 +72,7 @@ def status(ctx):
                 ),
             )
         ]
-        print(render_output(render_table, output=ctx.obj['args'].output))
+        print(render_output(render_table, output=ctx.obj["args"].output))
 
 
 @click.command()

--- a/src/pvecontrol/actions/cluster.py
+++ b/src/pvecontrol/actions/cluster.py
@@ -64,25 +64,7 @@ def status(ctx):
                 status=status,
                 vm=vms - templates,
                 templates=templates,
-                metrics=dict(
-                    cpu=dict(
-                        usage=metrics["cpu"]["usage"],
-                        total=metrics["cpu"]["total"],
-                        percent=metrics["cpu"]["percent"],
-                        allocated=metrics["cpu"]["allocated"],
-                    ),
-                    memory=dict(
-                        usage=metrics["memory"]["usage"],
-                        total=metrics["memory"]["total"],
-                        percent=metrics["memory"]["percent"],
-                        allocated=metrics["memory"]["allocated"],
-                    ),
-                    disk=dict(
-                        usage=metrics["disk"]["usage"],
-                        total=metrics["disk"]["total"],
-                        percent=metrics["disk"]["percent"],
-                    ),
-                ),
+                metrics=metrics,
                 nodes=dict(
                     offline=len([node for node in proxmox.nodes if node.status == NodeStatus.OFFLINE]),
                     online=len([node for node in proxmox.nodes if node.status == NodeStatus.ONLINE]),

--- a/src/pvecontrol/actions/cluster.py
+++ b/src/pvecontrol/actions/cluster.py
@@ -1,5 +1,4 @@
 import sys
-import textwrap
 
 import click
 
@@ -43,21 +42,20 @@ def status(ctx):
         d_percent = metrics["disk"]["percent"]
         return f"{d_usage}/{d_total}({d_percent:.1f}%)"
 
-    if _args.output == OutputFormats.TEXT:
-        output = f"""\
-            Status: {status}
-            VMs: {vms - templates}
-            Templates: {templates}
-            Metrics:
-                CPU: {_get_cpu_output()}
-                Memory: {_get_memory_output()}
-                Disk: {_get_disk_output()}
-            Nodes:
-                Offline: {len([node for node in proxmox.nodes if node.status == NodeStatus.OFFLINE])}
-                Online: {len([node for node in proxmox.nodes if node.status == NodeStatus.ONLINE])}
-                Unknown: {len([node for node in proxmox.nodes if node.status == NodeStatus.UNKNOWN])}
-            """
-        print(textwrap.dedent(output))
+    if ctx.obj['args'].output == OutputFormats.TEXT:
+        print(f"""\n\
+  Status: {status}
+  VMs: {vms - templates}
+  Templates: {templates}
+  Metrics:
+    CPU: {_get_cpu_output()}
+    Memory: {_get_memory_output()}
+    Disk: {_get_disk_output()}
+  Nodes:
+    Offline: {len([node for node in proxmox.nodes if node.status == NodeStatus.OFFLINE])}
+    Online: {len([node for node in proxmox.nodes if node.status == NodeStatus.ONLINE])}
+    Unknown: {len([node for node in proxmox.nodes if node.status == NodeStatus.UNKNOWN])}
+""")
     else:
         render_table = [
             dict(
@@ -72,10 +70,13 @@ def status(ctx):
                 ),
             )
         ]
-        print(render_output(render_table, output=_args.output))
+        print(render_output(render_table, output=ctx.obj['args'].output))
 
 
-def action_sanitycheck(proxmox, args):
+@click.command()
+@click.argument("checks", nargs=-1, type=click.Choice(list(DEFAULT_CHECK_IDS), case_sensitive=False))
+@click.pass_context
+def sanitycheck(ctx, checks):
     """Check status of proxmox Cluster"""
     # More checks to implement
     # VM is started but 'startonboot' not set

--- a/src/pvecontrol/actions/cluster.py
+++ b/src/pvecontrol/actions/cluster.py
@@ -44,7 +44,7 @@ def status(ctx):
 
     if ctx.obj['args'].output == OutputFormats.TEXT:
         print(f"""\n\
-  Status: {status}
+  Status: {cluster_status}
   VMs: {vms - templates}
   Templates: {templates}
   Metrics:
@@ -59,7 +59,7 @@ def status(ctx):
     else:
         render_table = [
             dict(
-                status=status,
+                status=cluster_status,
                 vm=vms - templates,
                 templates=templates,
                 metrics=metrics,

--- a/src/pvecontrol/actions/cluster.py
+++ b/src/pvecontrol/actions/cluster.py
@@ -59,17 +59,19 @@ def status(ctx):
 """
         )
     else:
-        render_table = [{
-            "status": cluster_status,
-            "vm": vms - templates,
-            "templates": templates,
-            "metrics": metrics,
-            "nodes": {
-                "offline": len([node for node in proxmox.nodes if node.status == NodeStatus.OFFLINE]),
-                "online": len([node for node in proxmox.nodes if node.status == NodeStatus.ONLINE]),
-                "unknown": len([node for node in proxmox.nodes if node.status == NodeStatus.UNKNOWN]),
+        render_table = [
+            {
+                "status": cluster_status,
+                "vm": vms - templates,
+                "templates": templates,
+                "metrics": metrics,
+                "nodes": {
+                    "offline": len([node for node in proxmox.nodes if node.status == NodeStatus.OFFLINE]),
+                    "online": len([node for node in proxmox.nodes if node.status == NodeStatus.ONLINE]),
+                    "unknown": len([node for node in proxmox.nodes if node.status == NodeStatus.UNKNOWN]),
+                },
             }
-        }]
+        ]
         print(render_output(render_table, output=ctx.obj["args"].output))
 
 

--- a/src/pvecontrol/utils.py
+++ b/src/pvecontrol/utils.py
@@ -91,7 +91,8 @@ def render_output(table, columns=None, sortby=None, filters=None, output=OutputF
     if output == OutputFormats.CSV:
         return x.get_csv_string(sortby=sortby, fields=columns)
     if output in (OutputFormats.JSON, OutputFormats.YAML):
-        json_string = x.get_json_string(sortby=sortby, fields=columns)
+        json_string = x.get_json_string()
+        # json_string = x.get_json_string(sortby=sortby, fields=columns)
         data = json.loads(json_string)[1:]
         if output == OutputFormats.JSON:
             return json.dumps(data)

--- a/src/pvecontrol/utils.py
+++ b/src/pvecontrol/utils.py
@@ -13,7 +13,7 @@ from enum import Enum
 import yaml
 
 from humanize import naturalsize
-from prettytable import PrettyTable
+from prettytable import PrettyTable, TableStyle
 
 
 class Fonts:
@@ -31,6 +31,7 @@ class OutputFormats(Enum):
     JSON = "json"
     CSV = "csv"
     YAML = "yaml"
+    MARKDOWN = "md"
 
     def __str__(self):
         return self.value
@@ -83,7 +84,9 @@ def render_output(table, columns=None, sortby=None, filters=None, output=OutputF
     if sortby is not None:
         sortby = "sortby"
 
-    if output == OutputFormats.TEXT:
+    if output in (OutputFormats.TEXT, OutputFormats.MARKDOWN):
+        if output == OutputFormats.MARKDOWN:
+            x.set_style(TableStyle.MARKDOWN)
         return x.get_string(sortby=sortby, fields=columns)
     if output == OutputFormats.CSV:
         return x.get_csv_string(sortby=sortby, fields=columns)

--- a/src/pvecontrol/utils.py
+++ b/src/pvecontrol/utils.py
@@ -91,8 +91,7 @@ def render_output(table, columns=None, sortby=None, filters=None, output=OutputF
     if output == OutputFormats.CSV:
         return x.get_csv_string(sortby=sortby, fields=columns)
     if output in (OutputFormats.JSON, OutputFormats.YAML):
-        json_string = x.get_json_string()
-        # json_string = x.get_json_string(sortby=sortby, fields=columns)
+        json_string = x.get_json_string(sortby=sortby, fields=columns)
         data = json.loads(json_string)[1:]
         if output == OutputFormats.JSON:
             return json.dumps(data)

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -22,8 +22,10 @@ def test_render_output():
     output_json = render_output(vms, columns=COLUMNS, output=OutputFormats.JSON)
     output_csv = render_output(vms, columns=COLUMNS, output=OutputFormats.CSV)
     output_yaml = render_output(vms, columns=COLUMNS, output=OutputFormats.YAML)
+    output_md = render_output(vms, columns=COLUMNS, output=OutputFormats.MARKDOWN)
 
     assert output_text.split("\n")[0].replace("+", "").replace("-", "") == ""
     assert len(json.loads(output_json)) == 3
     assert len(list(csv.DictReader(StringIO(output_csv)))) == 3
     assert len(yaml.safe_load(output_yaml)) == 3
+    assert len(output_md.split("\n")) == 5


### PR DESCRIPTION
- support output (`-o format`) option for `clusterstatus`
- add a markdown table output (`-o md`) (kudos @abuisine suggestion)
- py38-compat fixes