### PR TITLE
feat: add pvecontrol vm restore command

### DIFF
--- a/src/pvecontrol/models/cluster.py
+++ b/src/pvecontrol/models/cluster.py
@@ -153,6 +153,7 @@ class PVECluster:
 
         result = None
         node_name = None
+        # FIXME: wouldn't be easier AND faster to iterate over all nodes and vms directly?
         for vm in self.resources_vms:
             if vm["vmid"] == vm_id:
                 node_name = vm["node"]

--- a/src/pvecontrol/models/vm.py
+++ b/src/pvecontrol/models/vm.py
@@ -77,6 +77,12 @@ class PVEVm:
         upid = self._api.nodes(self.node).qemu(self.vmid).migrate.post(**options)
         return upid
 
+    @staticmethod
+    def create(proxmox, vmid, target, **options):
+        if "force" in options:
+            options["force"] = 1 if options["force"] else 0
+        return proxmox.api.nodes(target).qemu().post(vmid=vmid, **options)
+
     def get_backup_jobs(self, proxmox):
         vm_backup_jobs = []
         for backup_job in proxmox.backup_jobs:


### PR DESCRIPTION
I didn't configured a shorthand for the `--force` flag since it would conflict with the shorthand of `--follow`. I could use `-F` instead but I think that for a potentially destructive action it is not that bad to always use the long form of that flag.

```
$ pvecontrol vm restore --help
Usage: pvecontrol vm restore [OPTIONS] VMID

  Restore a VM from a backup archive

Options:
  -t, --target NODEID    ID of the target node  [required]
  -a, --archive ARCHIVE  The archive to restore. Either the file system path
                         to a .tar or .vma file or a proxmox storage backup
                         volume identifier.  [required]
  -s, --storage STORAGE  Target storage ID where the VM's disks will be
                         created (defaults to the storage from the backup
                         configuration).
  --force                Overwrite existing VM
  -f, --follow           Wait task end
  -w, --wait             Follow task log output
  --help                 Show this message and exit.
```